### PR TITLE
Damper board clarifications

### DIFF
--- a/documentation/assembly_manual.md
+++ b/documentation/assembly_manual.md
@@ -100,7 +100,12 @@ Connecting all the sensors is very time consuming. A total of 3*88 = 264 wires a
 
 ## Connecting Damper Sensors (Optional)
 
-A second IPS and SCA are required for damper sensors. Damper sensors are optional. If not using damper sensors, the damper location is estimated using the hammer sensors.
+A second IPS and SCA are required for damper sensors. If using this second board, damper sensors are required, but the second IPS/SCA pair and the corresponding damper sensors are optional.
+If not using damper sensors, the damper location is estimated using the hammer sensors.
+
+When using damper sensors, the second IPS needs to be connected to the first via the J10 connector on both boards, which uses tha CAN bus. Note that the CAN bus
+is polarity based (high and low). As such, the "high" sides of the bus from both boards must be connected together and identically for the low. In other words, connect the
+left pin of the J10 connector on the first IPS board with the left pin of the J10 connector on the second IPS board, and likewise for the right pins.
 
 Damper keys are numbered starting at piano note A0 (0), through piano note C8 (87).
 

--- a/documentation/component_manual.md
+++ b/documentation/component_manual.md
@@ -323,6 +323,9 @@ If using a separate damper board, two wires connect hammer and damper IPS boards
 Note that the CAN bus
 is polarity based (high and low). As such, the "high" sides of the bus from both boards must be connected together and identically for the low. In other words, connect the
 left pin of the J10 connector on the first IPS board with the left pin of the J10 connector on the second IPS board, and likewise for the right pins.
+Note also that the CAN bus is sensitive to electromagnetic interference. Even though at the low speeds involved for this project you may get it to work with whatever
+piece of cable you use, for noise immunity and signal integrity it would be much better to use at least a twisted pair (as a cheap-and-simple option you can simply
+twist together a two-position piece of regular ribbon cable).
 
 Can use standard breadboard ribbon cable.
 

--- a/documentation/component_manual.md
+++ b/documentation/component_manual.md
@@ -320,6 +320,9 @@ Each connection needs 3 wires. Hammer sensors require 3 wires * 88 keys = 264 wi
 ### Hammer and Damper Board Connection
 
 If using a separate damper board, two wires connect hammer and damper IPS boards together. Connect J10 on the hammer IPS board to J10 on the damper IPS board.
+Note that the CAN bus
+is polarity based (high and low). As such, the "high" sides of the bus from both boards must be connected together and identically for the low. In other words, connect the
+left pin of the J10 connector on the first IPS board with the left pin of the J10 connector on the second IPS board, and likewise for the right pins.
 
 Can use standard breadboard ribbon cable.
 

--- a/documentation/firmware_manual.md
+++ b/documentation/firmware_manual.md
@@ -43,6 +43,12 @@ Most settings are unlikely to change and are not listed here. The following sett
 
 * teensy_ip, computer_ip, udp_port - For the copy of code on computer, edit *hammer_settings.cpp* and put values into the Teensy and computer IP addresses. If not using Ethernet, any numbers are ok.
 
+:warning:
+
+:eight_pointed_black_star: If using separate IPS board for measuring the damper position must switch the `canbus_enable` form `false` to `true` in this file!
+
+:warning:
+
 ## Hammer Runtime: src_hammer.cpp
 
 The firmware consists of a Class for each major item of functionality. The firmware *src_hammer.cpp* declares and instantiates all classes.

--- a/documentation/users_manual.md
+++ b/documentation/users_manual.md
@@ -249,6 +249,8 @@ The damper board Teensy processor is programmed separately from the hammer board
 
 The damper board has its own optional 2.8 inch TFT display.
 
+:warning: If using separate damper board, you must recompile the firmware for the hammer board, changing the `canbus_enable` variable form `false` to `true` in the `hammer_settings.cpp` file
+
 ## Caring for Stem Piano
 
 The CNY70 have a long, but finite lifetime.


### PR DESCRIPTION
Clarified how to connect the IPS for hammer and damper boards.

Clarified a sentence in which a naive reader could have mistakenly understood that the damper **sensors** are optional, but the IPS damper **board** is not.

Apologies for the end-of-file changes, apparently the editor I use (github integrated one in this case) changes that last line even if I don't touch it

Stressed the need to recompile the *hammer* firmware when adding a *damper* board (from the initial documentation it felt that just flipping the hardware switch was sufficient)